### PR TITLE
Avoid negative durations in PVFM schedule command

### DIFF
--- a/pvfm/schedule/schedule.go
+++ b/pvfm/schedule/schedule.go
@@ -35,7 +35,8 @@ type ScheduleEntry struct {
 
 func (s ScheduleEntry) String() string {
 	startTimeUnix := time.Unix(int64(s.StartUnix), 0)
-	dur := startTimeUnix.Sub(time.Unix(time.Now().Unix(), 0))
+	nowWithoutNanoseconds := time.Unix(time.Now().Unix(), 0)
+	dur := startTimeUnix.Sub(nowWithoutNanoseconds)
 
 	if dur > 0 {
 		return fmt.Sprintf(

--- a/pvfm/schedule/schedule.go
+++ b/pvfm/schedule/schedule.go
@@ -37,10 +37,17 @@ func (s ScheduleEntry) String() string {
 	startTimeUnix := time.Unix(int64(s.StartUnix), 0)
 	dur := startTimeUnix.Sub(time.Unix(time.Now().Unix(), 0))
 
-	return fmt.Sprintf(
-		"In %s (%v %v): %s - %s",
-		dur, s.StartTime, s.Timezone, s.Host, s.Name,
-	)
+	if dur > 0 {
+		return fmt.Sprintf(
+			"In %s (%v %v): %s - %s",
+			dur, s.StartTime, s.Timezone, s.Host, s.Name,
+		)
+	} else {
+		return fmt.Sprintf(
+			"Now: %s - %s",
+			s.Host, s.Name,
+		)
+	}
 }
 
 var (


### PR DESCRIPTION
Currently, the command lists a negative duration for the current show:

```
In -17m32s (2017-07-14 22:00:00 UTC): DJ Rod - Manestage Live Mix w/ @SD_DJRod
In 1h42m28s (2017-07-15 00:00:00 UTC): FruityFusion - Hardcore Wrap-up [18+]
In 3h42m28s (2017-07-15 02:00:00 UTC): Progressive Element - Elemental Sounds with Progressive Element
In 5h42m28s (2017-07-15 04:00:00 UTC): Bolt the Super-Pony - Music Is Timeless
In 18h42m28s (2017-07-15 17:00:00 UTC): Lycan - Lycan Dese Beats!
In 22h42m28s (2017-07-15 21:00:00 UTC): Thorinair - Glory Of The Night
In 24h42m28s (2017-07-15 23:00:00 UTC): Midli, Willow - Mixology
```