### PR TITLE
Updated stream links

### DIFF
--- a/cmd/aerial/pvfm.go
+++ b/cmd/aerial/pvfm.go
@@ -216,6 +216,9 @@ func streams(s *discordgo.Session, m *discordgo.Message, parv []string) error {
 		outputString += ":musical_note: " + element.ServerDescription + ":\n<" + strings.Replace(element.Listenurl, "aerial", "dj.bronyradio.com", -1) + ">\n"
 	}
 
+	outputString += "**Luna Radio Server:**\n"
+	outputString += "\n:musical_note: Luna Radio MP3 128Kbps Stream:\n<http://radio.ponyvillelive.com:8002/stream.mp3>\n:musical_note: Luna Radio Mobile MP3 64Kbps Stream:\n<http://radio.ponyvillelive.com:8002/mobile?;stream.mp3>\n"
+
 	outputString += "\n:cd: DJ Recordings:\n<https://pvfmsets.cf/var/93252527679639552/>9" + "\n:cd: Legacy DJ Recordings:\n<http://darkling.darkwizards.com/wang/BronyRadio/?M=D>"
 
 	s.ChannelMessageSend(m.ChannelID, outputString)

--- a/cmd/aerial/pvfm.go
+++ b/cmd/aerial/pvfm.go
@@ -216,7 +216,7 @@ func streams(s *discordgo.Session, m *discordgo.Message, parv []string) error {
 		outputString += ":musical_note: " + element.ServerDescription + ":\n<" + strings.Replace(element.Listenurl, "aerial", "dj.bronyradio.com", -1) + ">\n"
 	}
 
-	outputString += "\n:cd: DJ Recordings:\n<http://darkling.darkwizards.com/wang/BronyRadio/?M=D>"
+	outputString += "\n:cd: DJ Recordings:\n<https://pvfmsets.cf/var/93252527679639552/>9" + "\n:cd: Legacy DJ Recordings:\n<http://darkling.darkwizards.com/wang/BronyRadio/?M=D>"
 
 	s.ChannelMessageSend(m.ChannelID, outputString)
 

--- a/cmd/aerial/pvfm.go
+++ b/cmd/aerial/pvfm.go
@@ -216,7 +216,7 @@ func streams(s *discordgo.Session, m *discordgo.Message, parv []string) error {
 		outputString += ":musical_note: " + element.ServerDescription + ":\n<" + strings.Replace(element.Listenurl, "aerial", "dj.bronyradio.com", -1) + ">\n"
 	}
 
-	outputString += "**Luna Radio Server:**\n"
+	outputString += "**Luna Radio Servers:**\n"
 	outputString += "\n:musical_note: Luna Radio MP3 128Kbps Stream:\n<http://radio.ponyvillelive.com:8002/stream.mp3>\n:musical_note: Luna Radio Mobile MP3 64Kbps Stream:\n<http://radio.ponyvillelive.com:8002/mobile?;stream.mp3>\n"
 
 	outputString += "\n:cd: DJ Recordings:\n<https://pvfmsets.cf/var/93252527679639552/>9" + "\n:cd: Legacy DJ Recordings:\n<http://darkling.darkwizards.com/wang/BronyRadio/?M=D>"


### PR DESCRIPTION
This commit adds Luna Radio streams and the new recording location for .djon/.djoff commands. It keeps the old location for legacy and archival purposes, but will be removed once the link is 404'd