### PR TITLE
Added `bookmark` command which sends tagged info about current track

### DIFF
--- a/cmd/aerial/aerial.go
+++ b/cmd/aerial/aerial.go
@@ -58,6 +58,8 @@ func main() {
 	a.cs.AddCmd("stats", "shows radio station statistics for Ponyville FM", bot.NoPermissions, stats)
 	a.cs.AddCmd("dj", "shows which DJ is up next on Ponyville FM", bot.NoPermissions, stats)
 	a.cs.AddCmd("schedule", "shows the future radio schedule for Ponyville FM", bot.NoPermissions, schedule)
+	a.cs.AddCmd("bookmark", "sends info about the current track on Main stream with [**BOOKMARK**] tag, so you can easily find it", bot.NoPermissions, bookmark)
+	a.cs.AddCmd("bm", "short for `bookmark`", bot.NoPermissions, bookmark)
 	a.cs.AddCmd("printerfact", "shows useful facts about printers", bot.NoPermissions, printerFact)
 	a.cs.AddCmd("hipster", "hip me up fam", bot.NoPermissions, hipster)
 	a.cs.AddCmd("source", "source code information", bot.NoPermissions, source.Source)

--- a/cmd/aerial/pvfm.go
+++ b/cmd/aerial/pvfm.go
@@ -141,6 +141,31 @@ func schedule(s *discordgo.Session, m *discordgo.Message, parv []string) error {
 	return nil
 }
 
+func bookmark(s *discordgo.Session, m *discordgo.Message, parv []string) error {
+
+	i, err := pvfm.GetStats()
+	if err != nil {
+		log.Printf("Error getting the station info: %v, falling back to plan b", err)
+		return doStatsFromStation(s, m, parv)
+	}
+
+	st, err := station.GetStats()
+	if err != nil {
+		return err
+	}
+
+	authorChannel, err := s.UserChannelCreate(m.Author.ID)
+	if err != nil {
+		return err
+	}
+
+	s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("<@%s> bookmark now is in your DM!", m.Author.ID))
+	s.ChannelMessageSend(authorChannel.ID, fmt.Sprintf("[**BOOKMARK**] *use a channel search to find all your bookmarks*\n"+i.Main.Nowplaying))
+
+	return nil
+
+}
+
 func doStationRequest(s *discordgo.Session, m *discordgo.Message, parv []string) error {
 	stats, err := station.GetStats()
 	if err != nil {

--- a/internal/bot/help.go
+++ b/internal/bot/help.go
@@ -16,9 +16,8 @@ func (cs *CommandSet) help(s *discordgo.Session, m *discordgo.Message, parv []st
 			return err
 		}
 
-		s.ChannelMessageSend(authorChannel.ID, result)
-
 		s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("<@%s> check direct messages, help is there!", m.Author.ID))
+		s.ChannelMessageSend(authorChannel.ID, result)
 
 	default:
 		return ErrParvCountMismatch


### PR DESCRIPTION
This command sends info which basically can be found in results of `;np` about current track on Main stream via DM with tag [BOOKMARK] so that the user can find all bookmarked tracks in his DM.